### PR TITLE
Fix encodings

### DIFF
--- a/pyc2e/interfaces/interface.py
+++ b/pyc2e/interfaces/interface.py
@@ -30,7 +30,7 @@ def coerce_to_bytearray(source: StrOrByteString):
     """
     Coerce the source to a bytearray or return it if it already is one.
 
-    Encodes using latin-1 to start with.
+    Encodes using Windows-1252/CP-1252
 
     :param source: a str, bytes, or bytearray to ensure is a bytearray
     :return:
@@ -40,7 +40,7 @@ def coerce_to_bytearray(source: StrOrByteString):
     elif isinstance(source, bytes):
         return bytearray(source)
 
-    return bytearray(source.encode("latin-1"))
+    return bytearray(source.encode("cp1252"))
 
 
 def generate_scrp_header(

--- a/pyc2e/interfaces/response.py
+++ b/pyc2e/interfaces/response.py
@@ -113,7 +113,7 @@ class Response:
         # under cpython slicing a bytes to its original length doesn't
         # seem to create a copy of it (ids are ==, a is b, etc), so this
         # should be efficient enough when we don't modify length.
-        return self._data[:cutoff_length].decode("latin-1")
+        return self._data[:cutoff_length].decode("cp1252")
 
     @property
     def error(self) -> Union[bool, None]:


### PR DESCRIPTION
Closes #3 

This is written with the assumption that the unicode support mentioned in netbabel .so debug symbols as a way to support caching exported creatures to disk. This may come back to bite me later, but so far there's no evidence that CL changed their habits.